### PR TITLE
Allow browsers with javascript disabled to browse the page as normal. 

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,12 @@
 		p { width: 500px; }
 		.scrollv { overflow-y: auto; }
 	</style>
-
+	
+	<noscript>
+		<style>
+			body { overflow-x: auto; overflow-y: auto; }
+		</style>
+	</noscript>
 </head>
 
 <body>


### PR DESCRIPTION
I have added a fix to allow users without javascript to use the scrollbars as normal.
